### PR TITLE
BLADE-384 Corrected bundle symbolic name

### DIFF
--- a/liferay-workspace/extensions/scheduler-entry/src/main/resources/META-INF/module-log4j.xml
+++ b/liferay-workspace/extensions/scheduler-entry/src/main/resources/META-INF/module-log4j.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
 <log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
-	<category name="osgi.logging.com_liferay_blade_scheduler.entry">
+	<category name="osgi.logging.com_liferay_blade_scheduler_entry">
 		<priority value="INFO" />
 	</category>
 </log4j:configuration>


### PR DESCRIPTION
Relevant Tickets:
https://issues.liferay.com/browse/BLADE-384

Description
Code fixed the "." rather than "_" between scheduler and entry