### PR TITLE
BLADE-492 Update dependencies to avoid compilation issue caused by LPS-104539 | 7.0

### DIFF
--- a/gradle/apps/service-builder/adq/adq-service/build.gradle
+++ b/gradle/apps/service-builder/adq/adq-service/build.gradle
@@ -16,6 +16,7 @@ buildService {
 dependencies {
 	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "3.5.0"
 	compileOnly group: "com.liferay", name: "com.liferay.osgi.service.tracker.collections", version: "2.0.0"
+	compileOnly group: "com.liferay", name: "com.liferay.petra.io", version: "1.0.0"
 	compileOnly group: "com.liferay", name: "com.liferay.portal.spring.extender", version: "2.0.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.6.0"
 	compileOnly project(":apps:service-builder:adq:adq-api")

--- a/gradle/apps/service-builder/adq/adq-service/build.gradle
+++ b/gradle/apps/service-builder/adq/adq-service/build.gradle
@@ -18,7 +18,7 @@ dependencies {
 	compileOnly group: "com.liferay", name: "com.liferay.osgi.service.tracker.collections", version: "2.0.0"
 	compileOnly group: "com.liferay", name: "com.liferay.petra.io", version: "1.0.0"
 	compileOnly group: "com.liferay", name: "com.liferay.portal.spring.extender", version: "2.0.0"
-	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.6.0"
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.42.0"
 	compileOnly project(":apps:service-builder:adq:adq-api")
 
 	testCompile group: "com.liferay.arquillian", name: "com.liferay.arquillian.arquillian-container-liferay", version: "1.0.6"

--- a/gradle/apps/service-builder/basic/basic-service/build.gradle
+++ b/gradle/apps/service-builder/basic/basic-service/build.gradle
@@ -12,7 +12,7 @@ dependencies {
 	compileOnly group: "com.liferay", name: "com.liferay.osgi.service.tracker.collections", version: "2.0.0"
 	compileOnly group: "com.liferay", name: "com.liferay.petra.io", version: "1.0.0"
 	compileOnly group: "com.liferay", name: "com.liferay.portal.spring.extender", version: "2.0.0"
-	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.6.0"
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.42.0"
 	compileOnly project(":apps:service-builder:basic:basic-api")
 
 	testCompile group: "com.liferay.arquillian", name: "com.liferay.arquillian.arquillian-container-liferay", version: "1.0.6"

--- a/gradle/apps/service-builder/basic/basic-service/build.gradle
+++ b/gradle/apps/service-builder/basic/basic-service/build.gradle
@@ -10,6 +10,7 @@ buildService {
 dependencies {
 	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "3.5.0"
 	compileOnly group: "com.liferay", name: "com.liferay.osgi.service.tracker.collections", version: "2.0.0"
+	compileOnly group: "com.liferay", name: "com.liferay.petra.io", version: "1.0.0"
 	compileOnly group: "com.liferay", name: "com.liferay.portal.spring.extender", version: "2.0.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.6.0"
 	compileOnly project(":apps:service-builder:basic:basic-api")

--- a/gradle/apps/service-builder/jdbc/jdbc-service/build.gradle
+++ b/gradle/apps/service-builder/jdbc/jdbc-service/build.gradle
@@ -2,6 +2,7 @@ apply plugin: "com.liferay.portal.tools.service.builder"
 
 dependencies {
 	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "3.5.0"
+	compileOnly group: "com.liferay", name: "com.liferay.petra.io", version: "1.0.0"
 	compileOnly group: "com.liferay", name: "com.liferay.portal.spring.extender", version: "2.0.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.6.0"
 	compileOnly group: "org.osgi", name: "osgi.cmpn", version: "6.0.0"

--- a/gradle/apps/service-builder/jdbc/jdbc-service/build.gradle
+++ b/gradle/apps/service-builder/jdbc/jdbc-service/build.gradle
@@ -4,7 +4,7 @@ dependencies {
 	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "3.5.0"
 	compileOnly group: "com.liferay", name: "com.liferay.petra.io", version: "1.0.0"
 	compileOnly group: "com.liferay", name: "com.liferay.portal.spring.extender", version: "2.0.0"
-	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.6.0"
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.42.0"
 	compileOnly group: "org.osgi", name: "osgi.cmpn", version: "6.0.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "5.0.0"
 	compileOnly project(":apps:service-builder:jdbc:jdbc-api")

--- a/gradle/apps/service-builder/jndi/jndi-service/build.gradle
+++ b/gradle/apps/service-builder/jndi/jndi-service/build.gradle
@@ -2,6 +2,7 @@ apply plugin: "com.liferay.portal.tools.service.builder"
 
 dependencies {
 	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "3.5.0"
+	compileOnly group: "com.liferay", name: "com.liferay.petra.io", version: "1.0.0"
 	compileOnly group: "com.liferay", name: "com.liferay.portal.spring.extender", version: "2.0.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.6.0"
 	compileOnly group: "org.osgi", name: "osgi.cmpn", version: "6.0.0"

--- a/gradle/apps/service-builder/jndi/jndi-service/build.gradle
+++ b/gradle/apps/service-builder/jndi/jndi-service/build.gradle
@@ -4,7 +4,7 @@ dependencies {
 	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "3.5.0"
 	compileOnly group: "com.liferay", name: "com.liferay.petra.io", version: "1.0.0"
 	compileOnly group: "com.liferay", name: "com.liferay.portal.spring.extender", version: "2.0.0"
-	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.6.0"
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.42.0"
 	compileOnly group: "org.osgi", name: "osgi.cmpn", version: "6.0.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "5.0.0"
 	compileOnly project(":apps:service-builder:jndi:jndi-api")


### PR DESCRIPTION
https://issues.liferay.com/browse/BLADE-492 - 7.0 changes

After [LPS-104539](https://issues.liferay.com/browse/LPS-104539) code changes, service builder modules need some additional dependencies with "Petra IO", in case they have a Blob column.

I am updating build.gradle file from blade samples, adding the missing dependencies

Related PRs:

- master: https://github.com/lawrence-lee/liferay-blade-samples/pull/80
- 7.2: https://github.com/lawrence-lee/liferay-blade-samples/pull/79
- 7.1: https://github.com/lawrence-lee/liferay-blade-samples/pull/78
- 7.0: https://github.com/lawrence-lee/liferay-blade-samples/pull/77